### PR TITLE
Remove dangling comma in jQuery.geoselector.js

### DIFF
--- a/jQuery.geoselector.js
+++ b/jQuery.geoselector.js
@@ -5,7 +5,7 @@
 			stateSelector: "*[name='state']",
 			data: "divisions.json",
 			defaultCountry: "Australia",
-			defaultState: "Western Australia",
+			defaultState: "Western Australia"
 		}, options);
 
 		var countries = $(settings.countrySelector, this);


### PR DESCRIPTION
Creation of the settings variable contains a dangling comma at the end of defaultState.
This causes problems in IE7 and below.
Comma has been removed.
